### PR TITLE
fix: MustImplemet 메타 데이터 오류 수정

### DIFF
--- a/Source/LocalUIManager/Public/LocalUIManagerSettings.h
+++ b/Source/LocalUIManager/Public/LocalUIManagerSettings.h
@@ -15,13 +15,13 @@ class LOCALUIMANAGER_API ULocalUIManagerSettings : public UDeveloperSettings
     GENERATED_BODY()
 
 protected:
-    UPROPERTY(Config, EditDefaultsOnly, Category = "Settings", meta = (MustImplement = "Interface_ModalWidget"))
+    UPROPERTY(Config, EditDefaultsOnly, Category = "Settings", meta = (MustImplement = "/Script/LocalUIManager.Interface_ModalWidget"))
     TSoftClassPtr<UUserWidget> DefaultAlertWidgetClass;
 
-    UPROPERTY(Config, EditDefaultsOnly, Category = "Settings", meta = (MustImplement = "Interface_ModalWidget"))
+    UPROPERTY(Config, EditDefaultsOnly, Category = "Settings", meta = (MustImplement = "/Script/LocalUIManager.Interface_ModalWidget"))
     TSoftClassPtr<UUserWidget> DefaultConfirmWidgetClass;
 
-    UPROPERTY(Config, EditDefaultsOnly, Category = "Settings", meta = (MustImplement = "Interface_ModalWidget"))
+    UPROPERTY(Config, EditDefaultsOnly, Category = "Settings", meta = (MustImplement = "/Script/LocalUIManager.Interface_ModalWidget"))
     TSoftClassPtr<UUserWidget> DefaultPromptWidgetClass;
 
 public:


### PR DESCRIPTION
UE 5.7.4에서는 MustImplement 메타 데이터 사용 시 Full Name 사용이 필수입니다.